### PR TITLE
add simple demos for map subcomponents

### DIFF
--- a/examples/simple-control-zoom.html
+++ b/examples/simple-control-zoom.html
@@ -10,10 +10,9 @@
   <link rel="import" href="../px-map.html" />
   <link rel="import" href="../px-map-tile-layer.html" />
   <link rel="import" href="../px-map-control-zoom.html" />
-
 </head>
 
-<style is="custom-style">
+<style>
   .wrap {
     display: flex;
     height: 100vh;
@@ -24,9 +23,7 @@
     <px-map zoom="10" lat="37.7749" lng="-122.4312" flex-to-size>
       <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
       <!-- Positions a zoom control in the bottomright -->
-      <px-map-control-zoom
-        position="bottomleft">
-      </px-map-control-zoom>
+      <px-map-control-zoom position="bottomleft"></px-map-control-zoom>
     </px-map>
   </section>
 </body>

--- a/examples/simple-layer-group.html
+++ b/examples/simple-layer-group.html
@@ -15,7 +15,7 @@
   <link rel="import" href="../px-map-popup-info.html" />
 </head>
 
-<style is="custom-style">
+<style>
   body {
     margin: 0;
   }

--- a/examples/simple-map-marker-static.html
+++ b/examples/simple-map-marker-static.html
@@ -23,11 +23,7 @@
   <section class="wrap">
     <px-map zoom="10" flex-to-size fit-to-markers>
       <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
-      <px-map-marker-static
-        lat="37.0"
-        lng="-122.0"
-        type="info">
-      </px-map-marker-static>
+      <px-map-marker-static lat="37.0" lng="-122.0" type="info"></px-map-marker-static>
     </px-map>
   </section>
 </body>

--- a/examples/simple-marker-group.html
+++ b/examples/simple-marker-group.html
@@ -9,13 +9,13 @@
   <!-- Importing px-map subcomponents... -->
   <link rel="import" href="../px-map.html" />
   <link rel="import" href="../px-map-tile-layer.html" />
-  <link rel="import" href="../../px-map-marker-group.html" />
+  <link rel="import" href="../px-map-marker-group.html" />
 
   <!-- Importing for the demo only... -->
   <link rel="import" href="../iron-ajax/iron-ajax.html" />
 </head>
 
-<style is="custom-style">
+<style>
   body {
     margin: 0;
   }
@@ -27,17 +27,16 @@
 <body>
   <section class="wrap">
     <template is="dom-bind">
-      <!-- Load geojson for markers with iron-ajax -->
+      <!-- Load `geoJSON` for markers with iron-ajax -->
       <iron-ajax url="marker-clusters-geojson-transit.json" last-response="{{geoJSON}}" auto></iron-ajax>
 
       <px-map fit-to-markers flex-to-size>
-        <px-map-tile-layer url="http://api.tiles.mapbox.com/v3/aj.map-b0cn5uze/{z}/{x}/{y}.png"></px-map-tile-layer>
+        <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
 
         <!-- Data-bind the output of the iron-ajax call `geoJSON` to the marker group's `data` attribute -->
         <px-map-marker-group name="Plaques" data="{{geoJSON}}"></px-map-marker-group>
       </px-map>
     </template>
   </section>
-
 </body>
 </html>

--- a/examples/simple-popup-data.html
+++ b/examples/simple-popup-data.html
@@ -13,7 +13,7 @@
   <link rel="import" href="../px-map-popup-data.html" />
 </head>
 
-<style is="custom-style">
+<style>
   body {
     margin: 0;
   }
@@ -37,7 +37,6 @@
           data='{ "Employees" : "2000", "Parking" : "Yes", "Snacks" : "Yes", "Gym" : "No" }'>
         </px-map-popup-data>
       </px-map-marker-static>
-
     </px-map>
   </section>
 </body>

--- a/examples/simple-popup-info.html
+++ b/examples/simple-popup-info.html
@@ -13,7 +13,7 @@
   <link rel="import" href="../px-map-popup-info.html" />
 </head>
 
-<style is="custom-style">
+<style>
   body {
     margin: 0;
   }
@@ -33,10 +33,7 @@
       <!-- Places a marker on the map -->
       <px-map-marker-static lat="37.7673626" lng="-121.9595048" type="info" show-badge>
       <!-- Places an info popup on the marker -->
-        <px-map-popup-info
-          title="GE Digital"
-          description="We have great maps. Our maps are the best maps.">
-        </px-map-popup-info>
+        <px-map-popup-info title="GE Digital" description="We have great maps. Our maps are the best maps."></px-map-popup-info>
       </px-map-marker-static>
 
     </px-map>

--- a/examples/simple-tile-layer.html
+++ b/examples/simple-tile-layer.html
@@ -10,10 +10,9 @@
   <link rel="import" href="../px-map.html" />
   <link rel="import" href="../px-map-tile-layer.html" />
   <link rel="import" href="../px-map-marker-static.html" />
-
 </head>
 
-<style is="custom-style">
+<style>
   .wrap {
     display: flex;
     height: 100vh;
@@ -22,8 +21,7 @@
 <body>
   <section class="wrap">
     <px-map zoom="10" flex-to-size>
-     <px-map-tile-layer url="http://api.tiles.mapbox.com/v3/aj.map-b0cn5uze/{z}/{x}/{y}.png"></px-map-tile-layer>
-      <!--<px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>-->
+      <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
     </px-map>
   </section>
 </body>


### PR DESCRIPTION
Add simple demos for map subcomponents:

- px-map-control-zoom
- px-map-marker-static
- px-map-marker-group
- px-map-layer-group
- px-map-tile-layer
- px-map-popup-info
- px-map-popup-data