### PR TITLE
fix shields.io badges for sub-components

### DIFF
--- a/demo/px-map-control-info-demo.html
+++ b/demo/px-map-control-info-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-control-info"
+      parent-name="px-map"
       description="The px-map-control-info component is awesome!">
   </px-demo-header>
 

--- a/demo/px-map-control-locate-demo.html
+++ b/demo/px-map-control-locate-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-control-locate"
+      parent-name="px-map"
       description="The px-map-control-locate subcomponent places a button on
       the map that the user can tap to detect and center the map on their
       current location.">

--- a/demo/px-map-control-scale-demo.html
+++ b/demo/px-map-control-scale-demo.html
@@ -25,7 +25,8 @@
 
   <!-- Header -->
   <px-demo-header
-      module-name="px-map-control-scale" The scale control
+      module-name="px-map-control-scale"
+      parent-name="px-map"
       description="The px-map-control-scale subcomponent places a distance scale on the map.">
   </px-demo-header>
 

--- a/demo/px-map-control-zoom-demo.html
+++ b/demo/px-map-control-zoom-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-control-zoom"
+      parent-name="px-map"
       description="The px-map-control-zoom subcomponent places zoom controls in a corner of the map selected by the user.">
   </px-demo-header>
 

--- a/demo/px-map-layer-group-demo.html
+++ b/demo/px-map-layer-group-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-layer-group"
+      parent-name="px-map"
       description="The px-map-layer-group subcomponent allows the user to group together multiple related markers.">
   </px-demo-header>
 

--- a/demo/px-map-marker-direction-demo.html
+++ b/demo/px-map-marker-direction-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-marker-direction"
+      parent-name="px-map"
       description="The px-map component is awesome!">
   </px-demo-header>
 

--- a/demo/px-map-marker-group-demo.html
+++ b/demo/px-map-marker-group-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-marker-group"
+      parent-name="px-map"
       description="The px-map-marker-group subcomponent lets you load a large number of markers onto your map.">
   </px-demo-header>
 
@@ -181,7 +182,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "info",
-                    
+
                   }
                 },
                 "id": "10003"
@@ -200,7 +201,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "unknown",
-                    
+
                   }
                 },
                 "id": "10004"
@@ -219,7 +220,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "important",
-                    
+
                   }
                 },
                 "id": "10006"
@@ -238,7 +239,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "unknown",
-                    
+
                   }
                 },
                 "id": "10007"
@@ -257,7 +258,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "unknown",
-                    
+
                   }
                 },
                 "id": "10011"
@@ -276,7 +277,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "warning",
-                    
+
                   }
                 },
                 "id": "10012"
@@ -295,7 +296,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "info",
-                    
+
                   }
                 },
                 "id": "10013"
@@ -314,7 +315,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "important",
-                    
+
                   }
                 },
                 "id": "10015"
@@ -333,7 +334,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "unknown",
-                    
+
                   }
                 },
                 "id": "10016"
@@ -352,7 +353,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "warning",
-                    
+
                   }
                 },
                 "id": "10020"
@@ -371,7 +372,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "warning",
-                    
+
                   }
                 },
                 "id": "10023"
@@ -390,7 +391,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "warning",
-                    
+
                   }
                 },
                 "id": "10024"
@@ -409,7 +410,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "warning",
-                    
+
                   }
                 },
                 "id": "10025"
@@ -428,7 +429,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "warning",
-                    
+
                   }
                 },
                 "id": "10026"
@@ -447,7 +448,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "unknown",
-                    
+
                   }
                 },
                 "id": "10027"
@@ -466,7 +467,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "unknown",
-                    
+
                   }
                 },
                 "id": "10029"
@@ -485,7 +486,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "warning",
-                    
+
                   }
                 },
                 "id": "10031"
@@ -504,7 +505,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "info",
-                    
+
                   }
                 },
                 "id": "10032"
@@ -523,7 +524,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "unknown",
-                    
+
                   }
                 },
                 "id": "10033"
@@ -542,7 +543,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "unknown",
-                    
+
                   }
                 },
                 "id": "10034"
@@ -561,7 +562,7 @@
                   "marker-icon": {
                     "icon-base": "static-icon",
                     "icon-type": "warning",
-                    
+
                   }
                 },
                 "id": "10036"

--- a/demo/px-map-marker-locate-demo.html
+++ b/demo/px-map-marker-locate-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-marker-locate"
+      parent-name="px-map"
       description="The px-map-marker-locate subcomponent creates a geolocation
       marker which displays the user's current location on the map.">
   </px-demo-header>

--- a/demo/px-map-marker-static-demo.html
+++ b/demo/px-map-marker-static-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-marker-static"
+      parent-name="px-map"
       description="The px-map-marker-static subcomponent creates a static marker at a given location on the map.">
   </px-demo-header>
 

--- a/demo/px-map-marker-symbol-demo.html
+++ b/demo/px-map-marker-symbol-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-marker-symbol"
+      parent-name="px-map"
       description="The px-map-marker-symbol subcomponent creates a marker with a specified icon at a given location on the map.">
   </px-demo-header>
 

--- a/demo/px-map-popup-data-demo.html
+++ b/demo/px-map-popup-data-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-popup-data"
+      parent-name="px-map"
       description="The px-map-popup-data subcomponent displays a popup box with
       some data on a given marker when that marker is clicked.">
   </px-demo-header>

--- a/demo/px-map-popup-info-demo.html
+++ b/demo/px-map-popup-info-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-popup-info"
+      parent-name="px-map"
       description="The px-map-popup-info subcomponent displays a popup box with
       some text on a given marker when that marker is clicked.">
   </px-demo-header>

--- a/demo/px-map-tile-layer-bing-demo.html
+++ b/demo/px-map-tile-layer-bing-demo.html
@@ -24,6 +24,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-tile-layer-bing"
+      parent-name="px-map"
       description="Loads base layer tiles from the Bing Maps API">
   </px-demo-header>
 

--- a/demo/px-map-tile-layer-demo.html
+++ b/demo/px-map-tile-layer-demo.html
@@ -25,6 +25,7 @@
   <!-- Header -->
   <px-demo-header
       module-name="px-map-tile-layer"
+      parent-name="px-map"
       description="The px-map-tile-layer subcomponent loads a basemap from a given tile service.">
   </px-demo-header>
 


### PR DESCRIPTION
Currently the shields.io badges on the sub-component demo pages are broken. In this PR I've added the "parent-name" property for each demo page so the badges are pulled correctly.

I also noticed a weird description in "px-map-marker-direction-demo" but I don't see that one in the dropdown so maybe it's pre-release? We can talk offline.