### PR TITLE
add OSM attribution to demos

### DIFF
--- a/demo/px-map-control-info-demo.html
+++ b/demo/px-map-control-info-demo.html
@@ -40,7 +40,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map zoom="12" flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          zoom="12"
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
         </px-map>
       </div>

--- a/demo/px-map-control-locate-demo.html
+++ b/demo/px-map-control-locate-demo.html
@@ -42,7 +42,11 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-control-locate
             position="{{props.position.value}}"

--- a/demo/px-map-control-locate-demo.html
+++ b/demo/px-map-control-locate-demo.html
@@ -46,7 +46,7 @@
           flex-to-size
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-control-locate
             position="{{props.position.value}}"

--- a/demo/px-map-control-scale-demo.html
+++ b/demo/px-map-control-scale-demo.html
@@ -41,7 +41,11 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-control-scale
             position="{{props.position.value}}"

--- a/demo/px-map-control-scale-demo.html
+++ b/demo/px-map-control-scale-demo.html
@@ -45,7 +45,7 @@
           flex-to-size
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-control-scale
             position="{{props.position.value}}"

--- a/demo/px-map-control-zoom-demo.html
+++ b/demo/px-map-control-zoom-demo.html
@@ -43,7 +43,7 @@
         <px-map flex-to-size
                 disable-scroll-zoom
                 disable-touch-zoom
-                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-control-zoom position="{{props.position.value}}"></px-map-control-zoom>
         </px-map>

--- a/demo/px-map-control-zoom-demo.html
+++ b/demo/px-map-control-zoom-demo.html
@@ -40,7 +40,10 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map flex-to-size
+                disable-scroll-zoom
+                disable-touch-zoom
+                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-control-zoom position="{{props.position.value}}"></px-map-control-zoom>
         </px-map>

--- a/demo/px-map-demo.html
+++ b/demo/px-map-demo.html
@@ -45,7 +45,8 @@
           flex-to-size="{{props.flexToSize.value}}"
           disable-scroll-zoom="{{props.disableScrollZoom.value}}"
           disable-touch-zoom="{{props.disableScrollZoom.value}}"
-          disable-dragging="{{props.disableDragging.value}}">
+          disable-dragging="{{props.disableDragging.value}}"
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
         </px-map>
       </div>

--- a/demo/px-map-demo.html
+++ b/demo/px-map-demo.html
@@ -46,7 +46,7 @@
           disable-scroll-zoom="{{props.disableScrollZoom.value}}"
           disable-touch-zoom="{{props.disableScrollZoom.value}}"
           disable-dragging="{{props.disableDragging.value}}"
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
         </px-map>
       </div>

--- a/demo/px-map-layer-geojson-demo.html
+++ b/demo/px-map-layer-geojson-demo.html
@@ -44,7 +44,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:600px;width:800px;display:flex">
-        <px-map zoom="12" flex-to-size disable-touch-zoom lat="52.2352" lng="0.1127">
+        <px-map zoom="12"
+                flex-to-size
+                disable-touch-zoom
+                lat="52.2352"
+                lng="0.1127"
+                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-layer-geojson
               data="{{props.data.value}}"

--- a/demo/px-map-layer-geojson-demo.html
+++ b/demo/px-map-layer-geojson-demo.html
@@ -49,7 +49,7 @@
                 disable-touch-zoom
                 lat="52.2352"
                 lng="0.1127"
-                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-layer-geojson
               data="{{props.data.value}}"

--- a/demo/px-map-layer-group-demo.html
+++ b/demo/px-map-layer-group-demo.html
@@ -40,7 +40,11 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map fit-to-markers flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map fit-to-markers
+                flex-to-size
+                disable-scroll-zoom
+                disable-touch-zoom
+                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-layer-group name="{{props.name.value}}">
             <px-map-marker-static lat="37.8079" lng="-122.2687"></px-map-marker-static>

--- a/demo/px-map-layer-group-demo.html
+++ b/demo/px-map-layer-group-demo.html
@@ -44,7 +44,7 @@
                 flex-to-size
                 disable-scroll-zoom
                 disable-touch-zoom
-                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+                attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-layer-group name="{{props.name.value}}">
             <px-map-marker-static lat="37.8079" lng="-122.2687"></px-map-marker-static>

--- a/demo/px-map-marker-direction-demo.html
+++ b/demo/px-map-marker-direction-demo.html
@@ -45,7 +45,7 @@
           flex-to-size
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
         </px-map>
       </div>

--- a/demo/px-map-marker-direction-demo.html
+++ b/demo/px-map-marker-direction-demo.html
@@ -40,7 +40,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px; width:600px;display:flex">
-        <px-map zoom="12" flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          zoom="12"
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
         </px-map>
       </div>

--- a/demo/px-map-marker-group-demo.html
+++ b/demo/px-map-marker-group-demo.html
@@ -45,7 +45,7 @@
           fit-to-markers
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-group name="Bus stop data" data="{{props.data.value}}"></px-map-marker-group>
         </px-map>

--- a/demo/px-map-marker-group-demo.html
+++ b/demo/px-map-marker-group-demo.html
@@ -40,7 +40,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          flex-to-size
+          fit-to-markers
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-group name="Bus stop data" data="{{props.data.value}}"></px-map-marker-group>
         </px-map>

--- a/demo/px-map-marker-locate-demo.html
+++ b/demo/px-map-marker-locate-demo.html
@@ -47,7 +47,7 @@
           flex-to-size
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-locate
             lat="{{props.lat.value}}"

--- a/demo/px-map-marker-locate-demo.html
+++ b/demo/px-map-marker-locate-demo.html
@@ -41,7 +41,13 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px; width:600px;display:flex">
-        <px-map zoom="15" fit-to-markers flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          zoom="15"
+          fit-to-markers
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-locate
             lat="{{props.lat.value}}"

--- a/demo/px-map-marker-static-demo.html
+++ b/demo/px-map-marker-static-demo.html
@@ -45,7 +45,7 @@
           flex-to-size
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static
             lat="{{props.lat.value}}"

--- a/demo/px-map-marker-static-demo.html
+++ b/demo/px-map-marker-static-demo.html
@@ -40,7 +40,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px; width:600px;display:flex">
-        <px-map zoom="8" flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          zoom="8"
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static
             lat="{{props.lat.value}}"

--- a/demo/px-map-marker-symbol-demo.html
+++ b/demo/px-map-marker-symbol-demo.html
@@ -45,7 +45,7 @@
           flex-to-size
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-symbol
             lat="{{props.lat.value}}"

--- a/demo/px-map-marker-symbol-demo.html
+++ b/demo/px-map-marker-symbol-demo.html
@@ -40,7 +40,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px; width:600px;display:flex">
-        <px-map zoom="12" flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          zoom="12"
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-symbol
             lat="{{props.lat.value}}"

--- a/demo/px-map-popup-data-demo.html
+++ b/demo/px-map-popup-data-demo.html
@@ -46,7 +46,7 @@
           flex-to-size
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static lat="37.7673626" lng="-121.9595048" type="info">
             <px-map-popup-data

--- a/demo/px-map-popup-data-demo.html
+++ b/demo/px-map-popup-data-demo.html
@@ -41,7 +41,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map zoom="12" flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          zoom="12"
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static lat="37.7673626" lng="-121.9595048" type="info">
             <px-map-popup-data

--- a/demo/px-map-popup-info-demo.html
+++ b/demo/px-map-popup-info-demo.html
@@ -41,7 +41,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          flex-to-size
+          fit-to-markers
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static lat="42.3518414" lng="-71.0500149" type="info">
             <px-map-popup-info title="{{props.title.value}}" description="{{props.description.value}}"></px-map-popup-info>

--- a/demo/px-map-popup-info-demo.html
+++ b/demo/px-map-popup-info-demo.html
@@ -46,7 +46,7 @@
           fit-to-markers
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
           <px-map-marker-static lat="42.3518414" lng="-71.0500149" type="info">
             <px-map-popup-info title="{{props.title.value}}" description="{{props.description.value}}"></px-map-popup-info>

--- a/demo/px-map-tile-layer-demo.html
+++ b/demo/px-map-tile-layer-demo.html
@@ -40,7 +40,12 @@
     <!-- Component ---------------------------------------------------------->
     <px-demo-component>
       <div style="height:400px;width:600px;display:flex">
-        <px-map zoom="12" flex-to-size disable-scroll-zoom disable-touch-zoom>
+        <px-map
+          zoom="12"
+          flex-to-size
+          disable-scroll-zoom
+          disable-touch-zoom
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
           <px-map-tile-layer url="{{props.url.value}}"></px-map-tile-layer>
         </px-map>
       </div>

--- a/demo/px-map-tile-layer-demo.html
+++ b/demo/px-map-tile-layer-demo.html
@@ -45,7 +45,7 @@
           flex-to-size
           disable-scroll-zoom
           disable-touch-zoom
-          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap</a>'>
+          attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="{{props.url.value}}"></px-map-tile-layer>
         </px-map>
       </div>


### PR DESCRIPTION
### A description of the changes proposed in the pull request:
As pointed out on Slack, we need to add OSM attribution to our demo maps that use the OSM tile layer, as laid out in their [T&Cs](http://www.openstreetmap.org/copyright)

### A reference to a related issue (if applicable):
N/A

### @mentions of the person or team responsible for reviewing proposed changes:
@davidrleonard @talimarcus 