### PR TITLE
add title tag for locate marker (fixes #58)

### DIFF
--- a/px-map-behavior-marker.es6.js
+++ b/px-map-behavior-marker.es6.js
@@ -45,9 +45,7 @@
 
       /**
        * A human-readable name for this layer group. If a tooltip is attached,
-       * this name will be shown on hover over the marker. If the map has a layer
-       * control panel, the user will click this name to show, hide, or
-       * manipulate this layer.
+       * this name will be shown on hover over the marker.
        *
        * @type {String}
        */

--- a/px-map-behavior-marker.es6.js
+++ b/px-map-behavior-marker.es6.js
@@ -8,6 +8,9 @@
   /* Ensures the behavior namespace is created */
   window.PxMapBehavior = (window.PxMapBehavior || {});
 
+  /* Ensures the klass namespace is created */
+  window.PxMap = (window.PxMap || {});
+
   /**
    *
    * @polymerBehavior PxMapBehavior.Marker
@@ -453,7 +456,7 @@
       // `CircleMarker` which draws the base blue dot, and an optional `Circle`
       // representing the accuracy of the location. They're combined together
       // in a `FeatureGroup` to ensure they share interactive bindings like popups.
-      this.markerBaseIcon = L.circleMarker(options.geometry, options.baseConfig);
+      this.markerBaseIcon = new CircleMarkerWithTitle(options.geometry, options.baseConfig);
       this.markerAccuracyIcon = L.circle(options.geometry, options.accuracyRadius, options.accuracyConfig);
       this.markerGroup = L.featureGroup([this.markerAccuracyIcon, this.markerBaseIcon]);
 
@@ -499,6 +502,9 @@
       if (lastOptions.accuracyRadius !== nextOptions.accuracyRadius) {
         this.markerAccuracyIcon.setRadius(nextOptions.accuracyRadius);
       }
+      if (lastOptions.baseConfig.title !== nextOptions.baseConfig.title) {
+        this.markerBaseIcon.setTitle(nextOptions.baseConfig.title);
+      }
     },
 
     /**
@@ -520,6 +526,7 @@
       baseConfig.fillColor = this.getComputedStyleValue('--internal-px-map-marker-locate-icon-color');
       baseConfig.fillOpacity = 1;
       baseConfig.className = `map-marker-locate-base ${this.isShadyScoped() ? this.getShadyScope() : ''}`;
+      baseConfig.title = (this.name || '');
 
       // Calculates the radius of the circle from the accuracy passed in and
       // the minimum size required to draw the base marker
@@ -543,4 +550,31 @@
     PxMapBehavior.Marker,
     PxMapBehavior.LocateMarkerImpl
   ];
+
+  const CircleMarkerWithTitle = L.CircleMarker.extend({
+    options: {
+      title: ''
+    },
+
+    setTitle: function (title) {
+      this.options.title = title || '';
+      if (this._path && this.options.title === '') {
+        this._path.innerHTML = '';
+      }
+      if (this._path && this.options.title !== '') {
+        this._path.innerHTML = `<title>${this.options.title}</title>`;
+      }
+    },
+
+    onAdd: function() {
+      L.CircleMarker.prototype.onAdd.call(this);
+      if(this.options.title !== '') {
+        this._path.innerHTML = `<title>${this.options.title}</title>`;
+      }
+    }
+  });
+
+  /* Bind CircleMarkerWithTitle klass */
+  PxMap.CircleMarkerWithTitle = CircleMarkerWithTitle;
+
 })();

--- a/test/px-map-marker-fixture.html
+++ b/test/px-map-marker-fixture.html
@@ -23,6 +23,7 @@
     <!-- Load local components -->
     <link rel="import" href="../px-map.html" />
     <link rel="import" href="../px-map-marker-static.html" />
+    <link rel="import" href="../px-map-marker-locate.html" />
     <!-- Load tests -->
     <script src="px-map-marker-tests.js"></script>
   </head>
@@ -51,6 +52,18 @@
         <px-map style="height: 400px; width: 400px;">
           <px-map-marker-behavior-stub lat="34" lng=123></px-map-marker-behavior-stub>
         </px-map>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="LocateMarkerWithNameFixture">
+      <template>
+        <px-map-marker-locate name="i am a locate marker" lat="37" lng="122"></px-map-marker-locate>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="LocateMarkerWithoutNameFixture">
+      <template>
+        <px-map-marker-locate lat="37" lng="122"></px-map-marker-locate>
       </template>
     </test-fixture>
 

--- a/test/px-map-marker-fixture.html
+++ b/test/px-map-marker-fixture.html
@@ -57,16 +57,11 @@
 
     <test-fixture id="LocateMarkerWithNameFixture">
       <template>
-        <px-map-marker-locate name="i am a locate marker" lat="37" lng="122"></px-map-marker-locate>
+        <px-map style="height: 400px; width: 400px;">
+          <px-map-marker-locate name="i am a locate marker" lat="37" lng="122"></px-map-marker-locate>
+        </px-map>
       </template>
     </test-fixture>
-
-    <test-fixture id="LocateMarkerWithoutNameFixture">
-      <template>
-        <px-map-marker-locate lat="37" lng="122"></px-map-marker-locate>
-      </template>
-    </test-fixture>
-
 
   </body>
 </html>

--- a/test/px-map-marker-tests.js
+++ b/test/px-map-marker-tests.js
@@ -92,4 +92,58 @@ function runCustomTests() {
 
 });
 
+describe('px-map-marker-locate', function () {
+  var markerEl;
+  var markerOptions;
+  // var popupContent;
+  var sandbox;
+
+  beforeEach(function () {
+    markerEl = fixture('LocateMarkerWithNameFixture');
+    markerOptions = markerEl.getInstOptions();
+    markerInstance = markerEl.createInst(markerOptions);
+    // popupContent = popupInstance.getContent();
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('returns title property as configured through the `name` attribute (from `getInstOptions`)', function() {
+    expect(markerOptions.baseConfig).to.be.an('object');
+    expect(markerOptions.baseConfig).to.have.property('title').that.equals('i am a locate marker');
+  });
+
+  it('asks to update its title option when the `name` attribute is changed (with `shouldUpdateInst` observer)', function() {
+    var updateFn = sinon.spy(markerEl, 'shouldUpdateInst');
+    markerEl.set('name', 'A new name');
+
+    expect(updateFn).to.have.been.calledOnce;
+  });
+
+  it('updates title property when changed through the `name` attribute', function() {
+    markerEl.setAttribute('name', 'A new name');
+    setTimeout(function() {
+      expect(markerOptions.baseConfig).to.have.property('title').that.equals('A new name');
+      done();
+    }, 400);
+
+  });
+
+  // it('attempts to update its marker instance when the `name` attribute is changed (with `updateInst`)', function() {
+  //   // Create a fake `elementInst` to test whether `updateSettings` is called
+  //   var elementInst = {
+  //     updateInst: sinon.stub()
+  //   };
+  //   markerEl.elementInst = elementInst;
+  //
+  //   var lastOptions = { title: 'Old name'};
+  //   var nextOptions = { title: 'A new name'};
+  //   markerEl.updateInst(lastOptions, nextOptions);
+  //
+  //   expect(elementInst.updateInst).to.have.been.calledWithMatch(nextOptions);
+  // });
+});
+
 }

--- a/test/px-map-marker-tests.js
+++ b/test/px-map-marker-tests.js
@@ -93,14 +93,15 @@ function runCustomTests() {
 });
 
 describe('px-map-marker-locate', function () {
+  var locateMarkerFixture;
   var markerEl;
   var markerOptions;
   var sandbox;
 
   beforeEach(function () {
-    markerEl = fixture('LocateMarkerWithNameFixture');
+    locateMarkerFixture = fixture('LocateMarkerWithNameFixture');
+    markerEl = locateMarkerFixture.querySelector('px-map-marker-locate');
     markerOptions = markerEl.getInstOptions();
-    markerInstance = markerEl.createInst(markerOptions);
     sandbox = sinon.sandbox.create();
   });
 
@@ -126,14 +127,14 @@ describe('px-map-marker-locate', function () {
       expect(markerEl.getInstOptions().baseConfig).to.have.property('title').that.equals('A new name');
       done();
     });
-
   });
 
   it('puts the title tag into the path', function(done) {
     flush(function() {
+      var markerInstance = markerEl.elementInst;
       var layer;
       var keys = Object.keys(markerInstance._layers);
-      for (i=0; i<keys.length; i++) {
+      for (var i=0; i<keys.length; i++) {
         if (markerInstance._layers[keys[i]].options.title) {
           layer = markerInstance._layers[keys[i]];
         }
@@ -141,6 +142,7 @@ describe('px-map-marker-locate', function () {
       expect(layer.options.title).to.equal("i am a locate marker");
       var regex = /<title.*i am a locate marker<\/title>/
       expect(regex.test(layer._path.innerHTML)).to.equal(true);
+      done();
     });
   });
 

--- a/test/px-map-marker-tests.js
+++ b/test/px-map-marker-tests.js
@@ -95,14 +95,12 @@ function runCustomTests() {
 describe('px-map-marker-locate', function () {
   var markerEl;
   var markerOptions;
-  // var popupContent;
   var sandbox;
 
   beforeEach(function () {
     markerEl = fixture('LocateMarkerWithNameFixture');
     markerOptions = markerEl.getInstOptions();
     markerInstance = markerEl.createInst(markerOptions);
-    // popupContent = popupInstance.getContent();
     sandbox = sinon.sandbox.create();
   });
 
@@ -122,28 +120,30 @@ describe('px-map-marker-locate', function () {
     expect(updateFn).to.have.been.calledOnce;
   });
 
-  it('updates title property when changed through the `name` attribute', function() {
+  it('updates title property when changed through the `name` attribute', function(done) {
     markerEl.setAttribute('name', 'A new name');
-    setTimeout(function() {
-      expect(markerOptions.baseConfig).to.have.property('title').that.equals('A new name');
+    flush(function() {
+      expect(markerEl.getInstOptions().baseConfig).to.have.property('title').that.equals('A new name');
       done();
-    }, 400);
+    });
 
   });
 
-  // it('attempts to update its marker instance when the `name` attribute is changed (with `updateInst`)', function() {
-  //   // Create a fake `elementInst` to test whether `updateSettings` is called
-  //   var elementInst = {
-  //     updateInst: sinon.stub()
-  //   };
-  //   markerEl.elementInst = elementInst;
-  //
-  //   var lastOptions = { title: 'Old name'};
-  //   var nextOptions = { title: 'A new name'};
-  //   markerEl.updateInst(lastOptions, nextOptions);
-  //
-  //   expect(elementInst.updateInst).to.have.been.calledWithMatch(nextOptions);
-  // });
+  it('puts the title tag into the path', function(done) {
+    flush(function() {
+      var layer;
+      var keys = Object.keys(markerInstance._layers);
+      for (i=0; i<keys.length; i++) {
+        if (markerInstance._layers[keys[i]].options.title) {
+          layer = markerInstance._layers[keys[i]];
+        }
+      }
+      expect(layer.options.title).to.equal("i am a locate marker");
+      var regex = /<title.*i am a locate marker<\/title>/
+      expect(regex.test(layer._path.innerHTML)).to.equal(true);
+    });
+  });
+
 });
 
 }


### PR DESCRIPTION
- Extend Leaflet's L.CircleMarker to add a `title` option so that the native browser tooltip can show the locate marker's `name` on hover (if it has one)
- Add tests
- Remove extra documentation about the `name` property (re: "layer control panel")