### PR TITLE
Fix demo page timing errors caused by super fast new site 

### DIFF
--- a/demo/px-map-control-locate-demo.html
+++ b/demo/px-map-control-locate-demo.html
@@ -174,7 +174,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
         },
 
         siblingElement: {

--- a/demo/px-map-control-scale-demo.html
+++ b/demo/px-map-control-scale-demo.html
@@ -187,7 +187,7 @@
          },
 
          parentComponent: {
-           value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+           value: ['<div style="height:400px; width:600px; display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
          },
 
          siblingElement: {

--- a/demo/px-map-control-zoom-demo.html
+++ b/demo/px-map-control-zoom-demo.html
@@ -147,7 +147,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
         },
 
         siblingElement: {

--- a/demo/px-map-demo.html
+++ b/demo/px-map-demo.html
@@ -187,7 +187,7 @@
 
         parentComponent: {
           type: Array,
-          defaultValue: ['<div style="height:400px;width:600px;display:flex">','</div>']
+          defaultValue: ['<div style="height:400px; width:600px; display:flex">','</div>']
         },
 
         lightDomContent: {

--- a/demo/px-map-layer-geojson-demo.html
+++ b/demo/px-map-layer-geojson-demo.html
@@ -168,7 +168,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size disable-touch-zoom><px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer> ', '</px-map></div>']
+          value: ['<div style="height:600px; width:800px; display:flex"><px-map flex-to-size disable-touch-zoom><px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer> ', '</px-map></div>']
         }
       }
     });

--- a/demo/px-map-layer-group-demo.html
+++ b/demo/px-map-layer-group-demo.html
@@ -151,7 +151,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map fit-to-markers flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map fit-to-markers flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
         },
 
         siblingElement: {

--- a/demo/px-map-marker-direction-demo.html
+++ b/demo/px-map-marker-direction-demo.html
@@ -42,6 +42,7 @@
         <px-map
           zoom="12"
           flex-to-size
+          fit-to-markers
           disable-scroll-zoom
           disable-touch-zoom
           attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
@@ -167,7 +168,7 @@
         },
 
         parentComponent: {
-          value: ["<px-map flex-to-size disable-scroll-zoom disable-touch-zoom>", "</px-map>"]
+          value: ["<px-map flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom>", "</px-map>"]
         },
 
         siblingElement: {

--- a/demo/px-map-marker-group-demo.html
+++ b/demo/px-map-marker-group-demo.html
@@ -578,7 +578,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map fit-to-markers flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map fit-to-markers flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
         },
 
         siblingElement: {

--- a/demo/px-map-marker-locate-demo.html
+++ b/demo/px-map-marker-locate-demo.html
@@ -42,8 +42,8 @@
       <div style="height:400px; width:600px;display:flex">
         <px-map
           zoom="15"
-          fit-to-markers
           flex-to-size
+          fit-to-markers
           disable-scroll-zoom
           disable-touch-zoom
           attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
@@ -169,7 +169,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
         },
 
         siblingElement: {

--- a/demo/px-map-marker-static-demo.html
+++ b/demo/px-map-marker-static-demo.html
@@ -42,6 +42,7 @@
         <px-map
           zoom="8"
           flex-to-size
+          fit-to-markers
           disable-scroll-zoom
           disable-touch-zoom
           attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
@@ -169,7 +170,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
         },
 
         siblingElement: {

--- a/demo/px-map-marker-symbol-demo.html
+++ b/demo/px-map-marker-symbol-demo.html
@@ -42,6 +42,7 @@
         <px-map
           zoom="12"
           flex-to-size
+          fit-to-markers
           disable-scroll-zoom
           disable-touch-zoom
           attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
@@ -176,7 +177,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
         },
 
         siblingElement: {

--- a/demo/px-map-popup-data-demo.html
+++ b/demo/px-map-popup-data-demo.html
@@ -44,6 +44,7 @@
         <px-map
           zoom="12"
           flex-to-size
+          fit-to-markers
           disable-scroll-zoom
           disable-touch-zoom
           attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
@@ -161,7 +162,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map zoom="12" flex-to-size disable-scroll-zoom disable-touch-zoom><px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer><px-map-marker-static lat="37.7673626" lng="-121.9595048" type="info">', '</px-map-marker-static></px-map>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map zoom="12" flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom><px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer><px-map-marker-static lat="37.7673626" lng="-121.9595048" type="info">', '</px-map-marker-static></px-map>']
         }
       }
     });

--- a/demo/px-map-popup-data-demo.html
+++ b/demo/px-map-popup-data-demo.html
@@ -14,6 +14,7 @@
 <!-- Imports for this component -->
 <link rel="import" href="../px-map.html" />
 <link rel="import" href="../px-map-tile-layer.html" />
+<link rel="import" href="../px-map-marker-static.html" />
 <link rel="import" href="../px-map-popup-data.html" />
 
 <!-- Demo DOM module -->

--- a/demo/px-map-popup-info-demo.html
+++ b/demo/px-map-popup-info-demo.html
@@ -14,6 +14,7 @@
 <!-- Imports for this component -->
 <link rel="import" href="../px-map.html" />
 <link rel="import" href="../px-map-tile-layer.html" />
+<link rel="import" href="../px-map-marker-static.html" />
 <link rel="import" href="../px-map-popup-info.html" />
 
 <!-- Demo DOM module -->

--- a/demo/px-map-popup-info-demo.html
+++ b/demo/px-map-popup-info-demo.html
@@ -158,7 +158,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom><px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer><px-map-marker-static lat="42.3518414" lng="-71.0500149" type="info">', '</px-map-marker-static></px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map flex-to-size fit-to-markers disable-scroll-zoom disable-touch-zoom><px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer><px-map-marker-static lat="42.3518414" lng="-71.0500149" type="info">', '</px-map-marker-static></px-map></div>']
         }
       }
     });

--- a/demo/px-map-tile-layer-demo.html
+++ b/demo/px-map-tile-layer-demo.html
@@ -147,7 +147,7 @@
         },
 
         parentComponent: {
-          value: ['<div style="height:400px;width:600px;display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
+          value: ['<div style="height:400px; width:600px; display:flex"><px-map flex-to-size disable-scroll-zoom disable-touch-zoom>', '</px-map></div>']
         }
       }
     });

--- a/px-map-behavior-marker.es6.js
+++ b/px-map-behavior-marker.es6.js
@@ -61,7 +61,7 @@
      * be added to their parent.
      */
     canAddInst() {
-      return this.latLngIsValid(this.lat, this.lng);
+      return this.latLngIsValid(this.lat, this.lng, true);
     },
 
     /**
@@ -76,17 +76,21 @@
 
     /**
      * Returns true if lat and lng are valid values that can be used to set a
-     * marker's location. Prints an error if values are invalid.
+     * marker's location. Prints an error if values are invalid (unless `hideError`
+     * is set to true).
      *
      * @param {Number} lat
      * @param {Number} lng
+     * @param {Boolean} hideError
      * @return {Boolean}
      */
-    latLngIsValid(lat, lng) {
+    latLngIsValid(lat, lng, hideError) {
       var isValid = (typeof lat !== 'undefined' && this._canBeNum(lat)) && (typeof lng !== 'undefined' && this._canBeNum(lng));
       if (isValid) return true;
-      console.log(`PX-MAP CONFIGURATION ERROR:
+      if (!hideError) {
+        console.log(`PX-MAP CONFIGURATION ERROR:
         You entered an invalid \`lat\` or \`lng\` attribute for ${this.is}. You must pass a valid number.`);
+      }
       return false;
     },
 

--- a/px-map-behavior-popup.es6.js
+++ b/px-map-behavior-popup.es6.js
@@ -26,7 +26,7 @@
     },
 
     addInst(parent) {
-      if (parent && parent.getPopup() !== this.elementInst) {
+      if (parent && parent.getPopup && (parent.getPopup() !== this.elementInst)) {
         parent.bindPopup(this.elementInst);
 
         // Bind custom events for this cluster. Events will be unbound automatically.

--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -604,7 +604,7 @@
     },
 
     /**
-     * Returns true if val can be used as a number in L.LatLng
+     * Returns true if val can be used as a number in L.LatLng or zoom
      *
      * @param {*} val
      * @return {Boolean}
@@ -675,7 +675,7 @@
      *   * {Number} detail.lat - Latitude of the map centerpoint after moving
      *   * {Number} detail.lng - Longitude of the map centerpoint after moving
      *   * {Number} detail.zoom - Zoom level of the map after moving
-     *   * {L.LatLngBouds} detail.bounds - Custom Leaflet object describing the visible bounds of the map as a rectangle
+     *   * {L.LatLngBounds} detail.bounds - Custom Leaflet object describing the visible bounds of the map as a rectangle
      *
      * @event px-map-moved
      */

--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -464,7 +464,9 @@
     },
 
     canAddInst() {
-      return this.latLngIsValid(this.lat, this.lng);
+      if (typeof this.zoom !== 'undefined' && this._canBeNum(this.zoom)) {
+        return this.latLngIsValid(this.lat, this.lng, true);
+      }
     },
 
     createInst(options) {
@@ -613,17 +615,21 @@
 
     /**
      * Returns true if lat and lng are valid values that can be used to set a
-     * map's position. Prints an error if values are invalid.
+     * map's position. Prints an error if values are invalid (unless `hideError`
+     * is set to true).
      *
      * @param {Number} lat
      * @param {Number} lng
+     * @param {Boolean} hideError
      * @return {Boolean}
      */
-    latLngIsValid(lat, lng) {
+    latLngIsValid(lat, lng, hideError) {
       var isValid = (typeof lat !== 'undefined' && this._canBeNum(lat)) && (typeof lng !== 'undefined' && this._canBeNum(lng));
       if (isValid) return true;
-      console.log(`PX-MAP CONFIGURATION ERROR:
-        You entered an invalid \`lat\` or \`lng\` attribute for ${this.is}. You must pass a valid number.`);
+      if (!hideError) {
+        console.log(`PX-MAP CONFIGURATION ERROR:
+          You entered an invalid \`lat\` or \`lng\` attribute for ${this.is}. You must pass a valid number.`);
+      }
       return false;
     },
 

--- a/test/px-map-root-tests.js
+++ b/test/px-map-root-tests.js
@@ -155,8 +155,14 @@ function runCustomTests() {
       var invalidLatLng = mapEl.latLngIsValid("abc", 123, false);
 
       sinon.assert.calledOnce(console.log);
-      sinon.assert.calledWithExactly(console.log, `PX-MAP CONFIGURATION ERROR:
-        You entered an invalid \`lat\` or \`lng\` attribute for ${mapEl.is}. You must pass a valid number.`)
+      sinon.assert.match(console.log.args[0][0].replace(/\s+/g, ''), `PX-MAP CONFIGURATION ERROR:
+        You entered an invalid \`lat\` or \`lng\` attribute for ${mapEl.is}. You must pass a valid number.`.replace(/\s+/g, ''));
+    });
+
+    it('does not output a console log statement if the lat or lng is invalid and `hideError` is set to true', function() {
+      var invalidLatLng = mapEl.latLngIsValid("abc", 123, true);
+
+      sinon.assert.notCalled(console.log);
     });
 
     it('does not draw a map if we give it an invalid lat or lng value', function() {

--- a/test/px-map-root-tests.js
+++ b/test/px-map-root-tests.js
@@ -151,8 +151,8 @@ function runCustomTests() {
       expect(mapEl.latLngIsValid("","")).to.be.false;
     });
 
-    it('outputs a console log statement if the lat or lng is invalid', function() {
-      var invalidLatLng = mapEl.latLngIsValid("abc", 123);
+    it('outputs a console log statement if the lat or lng is invalid and `hideError` is set to false', function() {
+      var invalidLatLng = mapEl.latLngIsValid("abc", 123, false);
 
       sinon.assert.calledOnce(console.log);
       sinon.assert.calledWithExactly(console.log, `PX-MAP CONFIGURATION ERROR:


### PR DESCRIPTION
- Check that `zoom` is set before trying to draw the map
- Add `hideError` argument to `latLngIsValid` method so developer can choose to hide the console error if lat or lng is invalid. Update corresponding test.
- Check for `parent.getPopup` before calling it in `px-map-behavior-popup`'s `addInst` method
- Add sub-component imports and `fit-to-markers` attribute to demo pages so markers load and are visible
- Add spacing in demo-snippet for better readability