### PR TITLE
Expose disableDoubleClickZoom property

### DIFF
--- a/demo/px-map-demo.html
+++ b/demo/px-map-demo.html
@@ -43,7 +43,8 @@
           lng="{{props.lng.value}}"
           flex-to-size="{{props.flexToSize.value}}"
           disable-scroll-zoom="{{props.disableScrollZoom.value}}"
-          disable-touch-zoom="{{props.disableScrollZoom.value}}"
+          disable-touch-zoom="{{props.disableTouchZoom.value}}"
+          disable-double-click-zoom="{{props.disableDoubleClickZoom.value}}"
           disable-dragging="{{props.disableDragging.value}}"
           attribution-prefix='<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a> | &copy; <a href="http://osm.org/copyright">OpenStreetMap contributors</a>'>
           <px-map-tile-layer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"></px-map-tile-layer>
@@ -176,6 +177,12 @@
         disableTouchZoom: {
           type: Boolean,
           defaultValue: true,
+          inputType: 'toggle'
+        },
+
+        disableDoubleClickZoom: {
+          type: Boolean,
+          defaultValue: false,
           inputType: 'toggle'
         },
 

--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -583,6 +583,13 @@
         this.elementInst.touchZoom.disable();
       }
 
+      if (!lastOptions.doubleClickZoom && nextOptions.doubleClickZoom) {
+        this.elementInst.doubleClickZoom.enable();
+      }
+      if (lastOptions.doubleClickZoom && !nextOptions.doubleClickZoom) {
+        this.elementInst.doubleClickZoom.disable();
+      }
+
       if (lastOptions.attributionPrefix !== nextOptions.attributionPrefix) {
         this.elementInst.attributionControl.setPrefix(nextOptions.attributionPrefix);
       }

--- a/px-map-behavior-root.es6.js
+++ b/px-map-behavior-root.es6.js
@@ -400,6 +400,17 @@
       },
 
       /**
+       * Set to disable zooming on double-click.
+       *
+       * @type {Boolean}
+       */
+      disableDoubleClickZoom: {
+        type: Boolean,
+        value: false,
+        observer: 'shouldUpdateInst'
+      },
+
+      /**
        * Set to disable the attribution control, which can be used to show the
        * source of tile layers or other data overlays.
        *
@@ -526,6 +537,7 @@
       options.dragging = !this.disableDragging;
       options.scrollWheelZoom = !this.disableScrollZoom;
       options.touchZoom = !this.disableTouchZoom;
+      options.doubleClickZoom = !this.disableDoubleClickZoom;
       options.attributionControl = !this.disableAttribution;
       options.attributionPrefix = this.attributionPrefix;
 

--- a/test/px-map-root-fixture.html
+++ b/test/px-map-root-fixture.html
@@ -35,6 +35,16 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="DisableZoomMapFixture">
+      <template>
+        <px-map style="width:100px; height:100px;"
+                disable-scroll-zoom
+                disable-touch-zoom
+                disable-double-click-zoom>
+        </px-map>
+      </template>
+    </test-fixture>
+
     <test-fixture id="FitMarkersMapFixture">
       <template>
         <px-map style="width:300px; height:500px;" fit-to-markers>

--- a/test/px-map-root-tests.js
+++ b/test/px-map-root-tests.js
@@ -69,6 +69,29 @@ function runCustomTests() {
     });
   });
 
+  describe('Basic px-map with all zooming disabled', function () {
+    var mapEl;
+
+    beforeEach(function() {
+      mapEl = fixture('DisableZoomMapFixture');
+    });
+
+    it('has scroll wheel zoom disabled', function() {
+      var scrollZoom = mapEl.elementInst.options.scrollWheelZoom;
+      expect(scrollZoom).to.be.false;
+    });
+
+    it('has touch zoom disabled', function() {
+      var touchZoom = mapEl.elementInst.options.touchZoom;
+      expect(touchZoom).to.be.false;
+    });
+
+    it('has double click zoom disabled', function() {
+      var doubleClickZoom = mapEl.elementInst.options.doubleClickZoom;
+      expect(doubleClickZoom).to.be.false;
+    });
+});
+
   describe('Setting the geometry properties on px-map', function() {
     var mapEl;
     var sandbox;


### PR DESCRIPTION
Allows the developer to set disableDoubleClickZoom on their map to disable zooming in on double click and zooming out on shift+double click.